### PR TITLE
WIP: Improved Sidebar(s)

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -5,6 +5,11 @@
   - [Custom navbar](custom-navbar.md)
   - [Cover page](cover.md)
 
+- Test
+  - [Navbar](custom-navbar.md)
+    - [Themes](themes.md)
+    - [List of Plugins](plugins.md)
+
 - Customization
 
   - [Configuration](configuration.md)

--- a/index.html
+++ b/index.html
@@ -36,7 +36,7 @@
       loadSidebar: true,
       coverpage: true,
       name: 'docsify',
-      subMaxLevel: 2,
+      subMaxLevel: 3,
       mergeNavbar: true,
       formatUpdated: '{MM}/{DD} {HH}:{mm}',
       plugins: [
@@ -58,6 +58,39 @@
               + 'Last modified {docsify-updated} '
               + editHtml
           })
+          hook.doneEach(function() {
+            Array.prototype.slice.call(document.querySelectorAll(".sidebar-nav li")).forEach(function(li) {
+              li.childNodes.forEach(function(node) {
+                // wrap node text of li into its own paragraph
+                if (node.nodeName == '#text') {
+                  li.innerHTML = li.innerHTML.replace(node.nodeValue, '<p>' + node.nodeValue + '</p>')
+                  console.log('replaced', li)
+                }
+              })
+              // prepend an additional element for the chevron otherwise parent li clickarea is to big
+              li.childNodes[0].outerHTML = '<i class="icon"></i>' + li.childNodes[0].outerHTML
+            })
+            Array.prototype.slice.call(document.querySelectorAll(".sidebar li > ul ")).forEach(function(ul) {
+              const li = ul.parentElement
+              li.classList.add("nested-list-entry")
+              li.classList.add("expanded")
+              li.addEventListener("click", function(event) {
+                // ignore events catched by children
+                if (event.target === li || event.target.parentElement === li) {
+                  console.log('clicked', li)
+                  if (li.classList.contains("expanded")) {
+                    li.classList.add("collapsed")
+                    li.classList.remove("expanded")
+                    ul.classList.add('hidden')
+                  } else if (li.classList.contains("collapsed")) {
+                    li.classList.add("expanded")
+                    li.classList.remove("collapsed")
+                    ul.classList.remove('hidden')
+                  }
+                }
+              })
+            })
+          });
         }
       ]
     }

--- a/src/core/render/index.js
+++ b/src/core/render/index.js
@@ -13,7 +13,7 @@ import {prerenderEmbed} from './embed'
 
 function executeScript() {
   const script = dom
-    .findAll('.markdown-section>script')
+    .findAll('.markdown-content>script')
     .filter(s => !/template/.test(s.type))[0]
   if (!script) {
     return false
@@ -44,7 +44,7 @@ function renderMain(html) {
     html = '<h1>404 - Not found</h1>'
   }
 
-  this._renderTo('.markdown-section', html)
+  this._renderTo('.markdown-content', html)
   // Render sidebar with the TOC
   !this.config.loadSidebar && this._renderSidebar()
 
@@ -96,8 +96,8 @@ export function renderMixin(proto) {
     this._renderTo('.sidebar-nav', this.compiler.sidebar(text, maxLevel))
     const activeEl = getAndActive(this.router, '.sidebar-nav', true, true)
     if (loadSidebar && activeEl) {
-      activeEl.parentNode.innerHTML +=
-        this.compiler.subSidebar(subMaxLevel) || ''
+      //activeEl.parentNode.innerHTML +=
+      this._renderTo('.toc-bar', this.compiler.subSidebar(subMaxLevel) || '')
     } else {
       // Reset toc
       this.compiler.subSidebar()

--- a/src/core/render/tpl.js
+++ b/src/core/render/tpl.js
@@ -44,13 +44,22 @@ export function main(config) {
       '') +
     '<div class="sidebar-nav"><!--sidebar--></div>' +
     '</aside>'
-
   return (
+
     (isMobile ? `${aside}<main>` : `<main>${aside}`) +
-    '<section class="content">' +
-    '<article class="markdown-section" id="main"><!--main--></article>' +
-    '</section>' +
-    '</main>'
+    `
+    <section class="content">
+      <article class="markdown-section" style="display: flex;">
+        <div class="markdown-content" id="main" style="flex: none; width: 80%;">
+          <!--main-->
+        </div>
+        <div class="toc-bar" style="flex: none; width: 20%;">
+          <!--toc-bar-->
+        </div>
+      </article>
+    </section>
+    </main>
+    `
   )
 }
 

--- a/src/themes/basic/_layout.styl
+++ b/src/themes/basic/_layout.styl
@@ -468,3 +468,20 @@ body.close
 
   40%, 80%
     transform rotate(10deg)
+
+.nested-list-entry
+  cursor: pointer
+
+  &.expanded > .icon::before
+    content: '▼'
+  
+  &.collapsed > .icon::before
+    content: '▶'
+    
+  > .icon::before
+    font-size: 0.8em
+    padding-right: 4px
+    float: left
+
+.hidden
+  display: none

--- a/src/themes/vue.styl
+++ b/src/themes/vue.styl
@@ -39,12 +39,12 @@ body
     color var(--theme-color, $color-primary)
     font-weight 600
 
-.app-sub-sidebar
-  li
-    &::before
-      content '-'
-      padding-right 4px
-      float left
+// .app-sub-sidebar
+//   li
+//     &::before
+//       content '-'
+//       padding-right 4px
+//       float left
 
 /* markdown content found on pages */
 .markdown-section h1, .markdown-section h2, .markdown-section h3, .markdown-section h4, .markdown-section strong


### PR DESCRIPTION
- split TOC into own sidebar
- allow to collapse and expand sidebar

TODO:
- [ ] Use proper styles for TOC sidebar, add media query for smaller screens and merge the TOC into the main content section (without any right sidebar)
- [ ] Adjust styles for TOC sidebar (sticky position, own scroll bar)
- [ ] Scroll spy for TOC sidebar
- [ ] Improve icons for expand/collapse (more polished icons, more restricted selector for click area, improve UX when expandable icon is also a link)
- [ ] Store state what has been collapsed when open another page
- [ ] Make everything configurable: split TOC into its own sidebar, auto collapse items (by a specific level) expand hierarchy of current page automatically)
